### PR TITLE
Add GitHub Actions workflow for deploying Hugo site

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,45 @@
+name: Deploy Hugo site to Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+          fetch-depth: 0
+
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: 'latest'
+          extended: true
+
+      - name: Build
+        run: hugo --minify
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        if: github.ref == 'refs/heads/main'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public
+          publish_branch: gh-pages

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .vscode
 .hugo_build.lock
 .hugo_build.lock
+public/


### PR DESCRIPTION
- Introduced a new GitHub Actions workflow to automate the deployment of the Hugo site to GitHub Pages.
- Configured the workflow to trigger on pushes to the main branch and manual dispatch.
- Set up steps for checking out the repository, installing Hugo, building the site, and deploying to the gh-pages branch.
- Updated .gitignore to include the public directory for build artifacts.