### PR TITLE
Add dependency management step in GitHub Actions workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,8 @@ jobs:
         with:
           hugo-version: 'latest'
           extended: true
+      - name: Download dependencies
+        run: hugo mod tidy
 
       - name: Build
         run: hugo --minify


### PR DESCRIPTION
- Added a step to download Hugo module dependencies using 'hugo mod tidy' in the publish.yml workflow.
- This ensures that all required modules are properly fetched before building the site.